### PR TITLE
Inline CSS Sparkpost option

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -51,6 +51,7 @@ class Message extends BaseMessage
         'transactional' => 'options.transactional',
         'sandbox' => 'options.sandbox',
         'startTime' => 'options.start_time',
+        'inlineCss' => 'options.inline_css',
         'inline_images' => 'images',
         'attachments',
     ];


### PR DESCRIPTION
Hi and thank you for your extension!
There is a new SparkPost feature called inline_css and it is already implemented in sparkpost/sparkpost Composer package as 'inlineCss'.
Could you add this too?